### PR TITLE
Asset valuation reworked

### DIFF
--- a/crypto_pnl/asset.py
+++ b/crypto_pnl/asset.py
@@ -6,55 +6,33 @@ class Asset:
         self.quantity = Decimal(quantity)
         self.symbol = symbol
 
-    def set_value(self, val):
-        self.value = Decimal(val)
+    def set_value(self, value_data, value_type):
+        self.value_data = Decimal(value_data)
+        self.value_type = value_type
 
     @property
     def has_value(self):
-        return hasattr(self, 'value')
-    
-    def __mul__(self, scalar):
-        result = Asset(self.quantity * scalar, self.symbol)
-        if self.has_value:
-            result.value = self.value * scalar
-        return result
-    
-    def __neg__(self):
-        return self.__mul__(Decimal(-1))
-    
-    def __add__(self, other):
-        result = Asset(self.quantity + other.quantity, self.symbol)
-        if self.has_value and other.has_value:
-            result.value = self.value + other.value
-        return result
-    
-    def __sub__(self, other):
-        result = Asset(self.quantity - other.quantity, self.symbol)
-        if self.has_value and other.has_value:
-            result.value = self.value - other.value
-        return result
+        return hasattr(self, 'value_data')
     
     def split(self, quantity):
         total_quantity = self.quantity
         self.quantity -= quantity
         other = Asset(quantity, self.symbol)
         if self.has_value:
-            unit_value = self.value / total_quantity
-            self.value = convert(self.quantity, unit_value)
-            other.set_value(convert(quantity, unit_value))
+            unit_value = self.value_data / total_quantity
+            self.value_data = convert(self.quantity, unit_value)
+            other.set_value(convert(quantity, unit_value), self.value_type)
         return other
     
     @property
     def value_str(self):
         if self.has_value:
-            return '{:10}'.format(display_fiat(self.value))
+            return '{:10}'.format(display_fiat(self.value_data))
         else:
-            return '     ???'
+            return '{:10}'.format(0)
 
     def __str__(self):
-        return '{:16} {:5} ({:10} {:3})'.format(
-            display(self.quantity), self.symbol, 
-            self.value_str, FIAT_SYMBOL)
+        return '{:16} {:5}'.format( display(self.quantity), self.symbol)
         
 
 def parse_price(price):

--- a/crypto_pnl/aux.py
+++ b/crypto_pnl/aux.py
@@ -13,12 +13,6 @@ def print_trade_summary(index, trade, wallet, journal, fees):
     print '\n{}'.format(line_title('[ Trade #{:5}]'.format(index)))
     print trade
 
-    print '\n{}'.format(line_title('[ Transaction Gains ]'))
-    print Trackers.headers_str()
-    print journal.trackers.get_subset([
-       trade.executed.symbol, 
-       trade.amount.symbol]).last_transaction_str
-
     print '\n{}'.format(line_title('[ Position ]'))
     print '{} (ACCOUNT)'.format(Positions.headers_str())
 
@@ -40,6 +34,12 @@ def print_trade_summary(index, trade, wallet, journal, fees):
     summary_journal_all.add_fees(fees)
     print summary_journal_all.total
     
+    print '\n{}'.format(line_title('[ Transaction Gains ]'))
+    print Trackers.headers_str()
+    print journal.trackers.get_subset([
+       trade.executed.symbol,
+       trade.amount.symbol]).last_transaction_str
+
     print
     
 

--- a/crypto_pnl/aux.py
+++ b/crypto_pnl/aux.py
@@ -12,106 +12,72 @@ from .exchange_rates import exchange_rates
 def print_trade_summary(index, trade, wallet, journal, fees):
     print '\n{}'.format(line_title('[ Trade #{:5}]'.format(index)))
     print trade
-    print line_trade_summary()
+
+    print '\n{}'.format(line_title('[ Transaction Gains ]'))
+    print Trackers.headers_str()
+    print journal.trackers.get_subset([
+       trade.executed.symbol, 
+       trade.amount.symbol]).last_transaction_str
+
+    print '\n{}'.format(line_title('[ Position ]'))
     print '{} (ACCOUNT)'.format(Positions.headers_str())
 
     summary_journal_main = Summary()
     summary_journal_main.calculate(journal.main.get_subset([trade.pair]))
-    summary_journal_main.calculate_total_value()
-    print '{}  {}:Main'.format(summary_journal_main.total, trade.pair)
+    print '{}   {}:Main'.format(summary_journal_main.total, trade.pair)
 
     summary_journal_traded = Summary()
     summary_journal_traded.calculate(journal.traded.get_subset([trade.pair]))
-    summary_journal_traded.calculate_total_value()
-    print '{}  {}:Traded'.format(summary_journal_traded.total, trade.pair)
+    print '{}   {}:Traded'.format(summary_journal_traded.total, trade.pair)
 
     summary_fees = Summary()
     summary_fees.add_fees(fees.get_subset([trade.fee.symbol]))
-    summary_fees.calculate_total_value()
-    print '{}  {}:Fee'.format(summary_fees.total, trade.pair)
-    print line_trade_summary()
+    print '{}   {}:Fee'.format(summary_fees.total, trade.pair)
     
+    print '\n{}'.format(line_title('[ Balance ]'))
     summary_journal_all = Summary()
     summary_journal_all.calculate(journal.all)
     summary_journal_all.add_fees(fees)
-    summary_journal_all.calculate_total_value()
-    print '{}  Portfolio'.format(summary_journal_all.total)
+    print summary_journal_all.total
     
-    #summary_wallet = Summary()
-    #summary_wallet.add_ballances(wallet)
-    #summary_wallet.add_fees(fees)
-    # summary_wallet.add_ballances(wallet.get_subset([
-    #     trade.executed.symbol, 
-    #     trade.amount.symbol]))
-    # summary_wallet.add_fees(fees.get_subset([
-    #     trade.fee.symbol]))
-    #summary_wallet.calculate_total_value()
-    #print summary_wallet.total
-    #print '{} ({}:Wallet)'.format(summary_wallet.total, trade.pair)
-    print line_trade_summary()
-    #print wallet
-    print Trackers.headers_str()
-    print journal.trackers
-    # print '{}  Gains'.format(journal.trackers.get_subset([
-    #     trade.executed.symbol, 
-    #     trade.amount.symbol]))
     print
     
 
 def print_final_summary(wallet, journal, fees):
+    print '\n{}'.format(line_title('[ Main ]'))
+    summary_main = Summary()
+    summary_main.calculate(journal.main)
+    print summary_main
+
+    print '\n{}'.format(line_title('[ Traded ]'))
+    summary_traded = Summary()
+    summary_traded.calculate(journal.traded)
+    print summary_traded
+    
+    print '\n{}'.format(line_title('[ Position ]'))
+    summary = Summary()
+    summary.calculate(summary_main.total)
+    summary.calculate(summary_traded.total)
+    print summary
+    
+    print '\n{}'.format(line_title('[ Fees ]'))
+    summary_fees = Summary()
+    summary_fees.add_fees(fees)
+    print summary_fees
+    
     print '\n{}'.format(line_title('[ Balance ]'))
     summary_wallet = Summary()
     summary_wallet.calculate(journal.all)
     summary_wallet.add_fees(fees)
-    summary_wallet.calculate_total_value()
     print summary_wallet
-
-    print '\n{}'.format(line_title('[ Position (Main) ]'))
-    summary_journal_main = Summary()
-    summary_journal_main.calculate(journal.main)
-    summary_journal_main.calculate_total_value()
-    print summary_journal_main
-    
-    print '\n{}'.format(line_title('[ Position (Traded) ]'))
-    summary_journal_traded = Summary()
-    summary_journal_traded.calculate(journal.traded)
-    summary_journal_traded.calculate_total_value()
-    print summary_journal_traded
-
-    print '\n{}'.format(line_title('[ Fees ]'))
-    summary_fees = Summary()
-    summary_fees.add_fees(fees)
-    summary_fees.calculate_total_value()
-    print summary_fees
-    
-    summary_main = Summary()
-    summary_main.calculate(journal.main)
-    summary_main.calculate_total_value()
-
-    print '\n{}'.format(line_title('[ Summary (Main) ]'))
-    print summary_main
-
-    summary_traded = Summary()
-    summary_traded.calculate(journal.traded)
-    summary_traded.calculate_total_value()
-
-    print '\n{}'.format(line_title('[ Summary (Traded) ]'))
-    print summary_traded
-    
-    summary = Summary()
-    summary.calculate(summary_main.total)
-    summary.calculate(summary_traded.total)
-    summary.calculate_total_value()
-    
-    print '\n{}'.format(line_title('[ Summary ]'))
-    print summary
-    
-    print line_trade_summary()
-    print wallet
 
     print '\n{}'.format(line_title('[ Gains ]'))
     print Trackers.headers_str()
     print journal.trackers.summary()
+
+    print '\n{}'.format(line_title('[ Wallet ]'))
+    print Wallet.headers_str()
+    print wallet
 
     print
 
@@ -132,15 +98,36 @@ def walk_trades(trades_path, market_data_paths):
     filter_main = None
     filter_asset = None
 
+    print('Transaction listing tool')
+    print('''
+    Available commands by example:
+        pair DOGEBTC
+        traded DOGE
+        main BTC
+        asset DOGE
+    ''')
     command = raw_input('T> ')
     if command.startswith('pair'):
         filter_pair = command[len('pair '):]
+        print('Listing transactions for pair {}'.format(filter_pair))
     if command.startswith('traded'):
         filter_traded = command[len('traded '):]
+        print('Listing transactions for traded {}'.format(filter_traded))
     if command.startswith('main'):
         filter_main = command[len('main '):]
+        print('Listing transactions for main {}'.format(filter_main))
     if command.startswith('asset'):
         filter_asset = command[len('asset '):]
+        print('Listing transactions for asset {}'.format(filter_asset))
+    
+    print('''
+    Available commands during listing:
+        run
+        quit
+
+    Press Enter to continue...
+    ''')
+    command = raw_input('T> ')
 
     for index, trade in enumerate(trades):
         if filter_pair and trade.pair != filter_pair:
@@ -161,6 +148,11 @@ def walk_trades(trades_path, market_data_paths):
             return
 
     print '(No more trades.)'
+    print('''
+    Available commands:
+        summary
+        quit
+    ''')
     while True:
         command = raw_input('\nT> ')
         if command == 'quit':

--- a/crypto_pnl/core.py
+++ b/crypto_pnl/core.py
@@ -26,7 +26,13 @@ SIDE_SELL = 'SELL'
 SIGN_BUY = 1
 SIGN_SELL = -1
 
-LINE_LENGTH = 122
+CURRENT_VALUE = 'value'
+ACQUIRE_VALUE = 'cost'
+DISPOSE_VALUE = 'earn'
+FEE_VALUE = 'fee'
+GAIN_VALUE = 'gain'
+
+LINE_LENGTH = 92
 
 
 def get_datetime(date):
@@ -42,6 +48,20 @@ def parse_side(side):
 
 def get_side(quantity):
     return SIDE_SELL if quantity < 0 else SIDE_BUY
+
+
+def get_main_value_type(sign):
+    return (
+        DISPOSE_VALUE 
+            if sign == SIGN_BUY else 
+        ACQUIRE_VALUE)
+
+
+def get_traded_value_type(sign):
+    return (
+        ACQUIRE_VALUE 
+            if sign == SIGN_BUY else 
+        DISPOSE_VALUE)
 
 
 def convert(quantity, rate):

--- a/crypto_pnl/exchange_rates.py
+++ b/crypto_pnl/exchange_rates.py
@@ -42,7 +42,7 @@ class ExchangeRates:
     def set_asset_value(self, asset):
         unit_value = self.exchange_rates.get(asset.symbol)
         if unit_value:
-            asset.set_value(convert(asset.quantity, unit_value))
+            asset.set_value(convert(asset.quantity, unit_value), CURRENT_VALUE)
     
     def will_execute(self, trade):
         self.set_trade_assets_value(trade)
@@ -72,42 +72,46 @@ class ExchangeRates:
     def set_trade_assets_value_from_main(self, trade):
         exchange_rate = self.get_exchange_rate(trade.amount.symbol)
         value = convert(trade.amount.quantity, exchange_rate)
-        trade.amount.set_value(value)
-        trade.executed.set_value(value)
+        trade.amount.set_value(value, get_main_value_type(trade.side))
+        trade.executed.set_value(value, get_traded_value_type(trade.side))
         trade.exchange_rate = exchange_rate
         trade.exchange_symbol = trade.amount.symbol
         if trade.fee.symbol == trade.amount.symbol:
             trade.fee.set_value(
-                convert(trade.fee.quantity, exchange_rate)
+                convert(trade.fee.quantity, exchange_rate),
+                FEE_VALUE
             )
         elif trade.fee.symbol == trade.executed.symbol:
             trade.fee.set_value(
                 convert(
                     convert(trade.fee.quantity, trade.price), 
-                    exchange_rate))
+                    exchange_rate),
+                FEE_VALUE)
         else:
             fee_exchange_rate = self.get_exchange_rate(trade.fee.symbol)
-            trade.fee.set_value(convert(trade.fee.quantity, fee_exchange_rate))
+            trade.fee.set_value(convert(trade.fee.quantity, fee_exchange_rate), FEE_VALUE)
     
     def set_trade_assets_value_from_traded(self, trade):
         exchange_rate = self.get_exchange_rate(trade.executed.symbol)
         value = convert(trade.executed.quantity, exchange_rate)
-        trade.executed.set_value(value)
-        trade.amount.set_value(value)
+        trade.executed.set_value(value, get_traded_value_type(trade.side))
+        trade.amount.set_value(value, get_main_value_type(trade.side))
         trade.exchange_rate = exchange_rate
         trade.exchange_symbol = trade.executed.symbol
         if trade.fee.symbol == trade.executed.symbol:
             trade.fee.set_value(
-                convert(trade.fee.quantity, exchange_rate)
+                convert(trade.fee.quantity, exchange_rate), 
+                FEE_VALUE
             )
         elif trade.fee.symbol == trade.amount.symbol:
             trade.fee.set_value(
                 convert(
                     unconvert(trade.fee.quantity, trade.price), 
-                    exchange_rate))
+                    exchange_rate),
+                FEE_VALUE)
         else:
             fee_exchange_rate = self.get_exchange_rate(trade.fee.symbol)
-            trade.fee.set_value(convert(trade.fee.quantity, fee_exchange_rate))
+            trade.fee.set_value(convert(trade.fee.quantity, fee_exchange_rate), FEE_VALUE)
     
 
 exchange_rates = ExchangeRates()

--- a/crypto_pnl/journal.py
+++ b/crypto_pnl/journal.py
@@ -49,6 +49,9 @@ class Journal:
         tracker_main = self.trackers.get(trade.amount.symbol, trade.amount.symbol)
         tracker_traded = self.trackers.get(trade.executed.symbol, trade.executed.symbol)
 
+        tracker_main.begin_transaction()
+        tracker_traded.begin_transaction()
+
         if trade.side == SIGN_SELL:
             position_traded.dispose(trade.executed)
             position_all_traded.dispose(trade.executed)

--- a/crypto_pnl/position.py
+++ b/crypto_pnl/position.py
@@ -10,30 +10,33 @@ class Position:
     def __init__(self, symbol):
         self.total_acquire = Asset(0, symbol)
         self.total_dispose = Asset(0, symbol)
-        self.total_acquire.set_value(0)
-        self.total_dispose.set_value(0)
         self.symbol = symbol
     
     def acquire(self, asset):
-        self.total_acquire += asset
+        self.total_acquire = Asset(
+            self.total_acquire.quantity + asset.quantity,
+            self.total_acquire.symbol)
     
     def dispose(self, asset):
-        self.total_dispose += asset
+        self.total_dispose = Asset(
+            self.total_dispose.quantity + asset.quantity,
+            self.total_dispose.symbol)
     
     @classmethod
     def headers_str(cls):
-        return ' {} {} {} {}|  {} {} '.format(
-            ' (ACQUIRED)'.rjust(16), ' ({})'.format(FIAT_SYMBOL).rjust(10), 
-            ' (DISPOSED)'.rjust(16), ' ({})'.format(FIAT_SYMBOL).rjust(10), 
-            ' (POSITION)'.rjust(16), ' ({})'.format(FIAT_SYMBOL).rjust(10)
+        return ' {} {}|  {} {}'.format(
+            '(ACQUIRED)'.rjust(16), 
+            '(DISPOSED)'.rjust(16), 
+            '(POSITION)'.rjust(16),
+            '(VALUE)'.rjust(10)
         )
 
     def __str__(self):
-        position = self.total_acquire - self.total_dispose
+        position = Asset(self.total_acquire.quantity - self.total_dispose.quantity, self.symbol)
         exchange_rates.set_asset_value(position)
-        return '{:16} {:10} {:16} {:10} | {:16} {:10}  '.format(
-            display(self.total_acquire.quantity), self.total_acquire.value_str, 
-            display(self.total_dispose.quantity), self.total_dispose.value_str, 
+        return '{:16} {:16} | {:16} {:10}'.format(
+            display(self.total_acquire.quantity),
+            display(self.total_dispose.quantity),
             display(position.quantity), position.value_str
         )
 

--- a/crypto_pnl/tracker.py
+++ b/crypto_pnl/tracker.py
@@ -14,6 +14,10 @@ class Tracker:
         self.acquire_stack = []
         self.dispose_stack = []
         self.matched = []
+        self.last_transaction_index = 0
+    
+    def begin_transaction(self):
+        self.last_transaction_index = len(self.matched)
     
     def acquire(self, asset):
         matched, remaining = self.match(asset, self.dispose_stack, SIGN_BUY)
@@ -29,7 +33,8 @@ class Tracker:
     
     def match(self, asset, stack, sign):
         matched = []
-        remaining = asset * 1
+        remaining = Asset(asset.quantity, asset.symbol)
+        remaining.set_value(asset.value_data, asset.value_type)
         while stack and remaining:
             borrowed = stack[-1]
             if borrowed.quantity <= remaining.quantity:
@@ -47,10 +52,12 @@ class Tracker:
 
     @classmethod
     def headers_str(cls):
-        return ' {} {} {} {}|  {} '.format(
-            ' (ACQUIRED)'.rjust(16), ' ({})'.format(FIAT_SYMBOL).rjust(10), 
-            ' (DISPOSED)'.rjust(16), ' ({})'.format(FIAT_SYMBOL).rjust(10), 
-            ' (GAINS {})'.format(FIAT_SYMBOL).rjust(16)
+        return ' {} {}|  {} {} {} '.format(
+            ' (ACQUIRED)'.rjust(16),
+            ' (DISPOSED)'.rjust(16),
+            ' (COST)'.rjust(10),
+            ' (EARN)'.rjust(10), 
+            ' (GAIN)'.rjust(10)
         )
     
     def summary(self):
@@ -62,27 +69,33 @@ class Tracker:
         for buy, sell in self.matched:
             total_buy += buy.quantity
             total_sell += sell.quantity
-            total_cost += buy.value
-            total_consideration += sell.value
+            total_cost += buy.value_data
+            total_consideration += sell.value_data
         buy = Asset(total_buy, self.symbol)
         sell = Asset(total_sell, self.symbol)
-        buy.set_value(total_cost)
-        sell.set_value(total_consideration)
+        buy.set_value(total_cost, ACQUIRE_VALUE)
+        sell.set_value(total_consideration, DISPOSE_VALUE)
         tracker.matched.append((buy, sell))
         return tracker
     
     def format_match(self, match):
         buy, sell = match
         position = Asset(sell.quantity - buy.quantity, self.symbol)
-        position.set_value(sell.value - buy.value)
-        return '{:16} {:10} {:16} {:10} | {:16} '.format(
-            display(buy.quantity), buy.value_str, 
-            display(sell.quantity), sell.value_str, 
-            position.value_str.rjust(16)
+        position.set_value(sell.value_data - buy.value_data, GAIN_VALUE)
+        return '{:16} {:16} | {:10} {:10} {:10} '.format(
+            display(buy.quantity), 
+            display(sell.quantity), 
+            buy.value_str.rjust(10), 
+            sell.value_str.rjust(10), 
+            position.value_str.rjust(10)
         )
 
     def __str__(self):
         return '\n'.join(map(self.format_match, self.matched))
+    
+    @property
+    def last_transaction_str(self):
+        return '\n'.join(map(self.format_match, self.matched[self.last_transaction_index:]))
 
 
 class Trackers:
@@ -106,6 +119,14 @@ class Trackers:
             subset.trackers[pair] = self.trackers[pair]
         return subset
     
+    def get_subset_rest(self, pairs):
+        subset = Trackers()
+        for pair in self.trackers:
+            if pair in pairs:
+                continue
+            subset.trackers[pair] = self.trackers[pair]
+        return subset
+    
     def summary(self):
         summary = Trackers()
         for k,v in self.trackers.items():
@@ -121,4 +142,11 @@ class Trackers:
                 '{:10} |{}'.format(k, v.format_match(m))
                 for k,v in sorted_items(self.trackers)
                 for m in v.matched)
+    
+    @property
+    def last_transaction_str(self):
+        return '\n'.join(
+                '{:10} |{}'.format(k, v.format_match(m))
+                for k,v in sorted_items(self.trackers)
+                for m in v.matched[v.last_transaction_index:])
 


### PR DESCRIPTION
## Findings
1. It is incorrect to link change of asset value directly with change in asset quantity, and change of asset quantity also doesn't make sense, as asset of given quantity is to be treated as one thing, and in order to change quantity one must split asset into two assets. 

2. Also when acquiring new asset with the same symbol it is incorrect to add new and existing asset values. Here is the situation: You buy 5 apples for 3 euro, and then 3 apples for 5 euro. If you just add, then you have 8 apples for 8 euro, but this is not true. For calculation of CGT one needs to look at these two transactions separately. So it is not the case that 1 apple in average costs 1 euro, but is is the case that there is 5 apples for 60 cents each, and 3 apples for 1.67 euro each. And if you now selling 5 apples, you sell 3 apples that you bought for 1.67 euro each first, and then you sell 2 apples that you bought for 60 cents each second. Say you sell those 5 apples for 8 euro, then your cost is 3*1.67 + 2*0.60 = 6.20 euro and since you earn 8 euro your gain is 1.80 euro, and your CGT from that is 0.60 cents.

## Changes
- Asset math operators `mul/add/sub/neg` were removed
- Asset value is set explicitly and it is now tagged with `value|cost|earn|fee|gain`
- Trackers were updated, as well as all summary and position classes
- Console printout has been rearranged
- Gains per transaction are printed and not all gains